### PR TITLE
Super and Group admins can create users, Super can also remove and re…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { MessageComponent } from './message/message.component';
 import { AddGroupComponent } from './chat/chat-dashboard/main-panel/add-group/add-group.component';
 import { AddUserComponent } from './chat/chat-dashboard/main-panel/user-management/add-user/add-user.component';
 import { UserManagementComponent } from './chat/chat-dashboard/main-panel/user-management/user-management.component';
+import { UpdateUserComponent } from './chat/chat-dashboard/main-panel/user-management/update-user/update-user.component';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { UserManagementComponent } from './chat/chat-dashboard/main-panel/user-m
     AddGroupComponent,
     AddUserComponent,
     UserManagementComponent,
+    UpdateUserComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/chat/chat-dashboard/main-panel/user-management/add-user/add-user.component.ts
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/add-user/add-user.component.ts
@@ -29,7 +29,9 @@ export class AddUserComponent implements OnInit {
     avatar: "placeholder.jpg",
 
     // Binding for the users password.
-    password: '123'
+    password: '123',
+
+    active: true
   }
   
   // Binding for adding the user to groups.

--- a/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.html
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.html
@@ -1,0 +1,94 @@
+<div class="flex flex-col">
+<div class="w-full grid grid-cols-2 gap-10 mt-6">
+
+    <div class="w-full">
+        <p class="text-sm uppercase font-semibold tracking-wide">Find a User</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none {{ errors?.hasErrors('username') ? 'border-red-500' : 'border-gray-400' }}" type="text" 
+                    placeholder="Username..." name="username" [(ngModel)]="username">
+            <button (click)="findUser()" class="ml-2 px-2 py-1 bg-green-500 text-white rounded self-end hover:bg-green-400 focus:outline-none">
+                Find
+            </button>
+        </div>
+        <div class="w-full h-1">
+            <p class="text-red-500 text-right text-xs" *ngFor="let error of errors?.getErrors('username')">{{ error }}</p>
+        </div>
+    </div>
+
+    <div *ngIf="userForm.active != null" class="flex items-center h-10 py-2 text-center self-end justify-self-end">
+        <button *ngIf="userForm.active" (click)="deactivateUser()" class="px-4 py-2 bg-red-500 rounded text-white">Deactivate Account</button>
+        <button *ngIf="!userForm.active" (click)="activateUser()" class="px-4 py-2 bg-green-500 rounded text-white">Activate Account</button>
+    </div>
+
+</div>
+
+<div class="w-full grid grid-cols-2 gap-x-10 gap-y-5 mt-6">
+
+    <div class="w-full">
+        <p class="text-sm uppercase font-semibold tracking-wide">Username</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none {{ errors?.hasErrors('username') ? 'border-red-500' : 'border-gray-400' }}" type="text" 
+                    placeholder="Username..." name="userForm.username" [(ngModel)]="userForm.username">
+        </div>
+        <div class="w-full h-1">
+            <p class="text-red-500 text-right text-xs" *ngFor="let error of errors?.getErrors('username')">{{ error }}</p>
+        </div>
+    </div>
+
+    <div class="w-full">
+        <p class="text-sm uppercase font-semibold tracking-wide">Email</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none {{ errors?.hasErrors('email') ? 'border-red-500' : 'border-gray-400' }}" type="text" 
+                    placeholder="Email..." name="userForm.email" [(ngModel)]="userForm.email">
+        </div>
+        <div class="w-full h-1">
+            <p class="text-red-500 text-right text-xs" *ngFor="let error of errors?.getErrors('email')">{{ error }}</p>
+        </div>
+    </div>
+
+    <div class="w-full">    
+        <p class="text-sm uppercase font-semibold tracking-wide">avatar</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none border-gray-400" type="text" 
+                    placeholder="Avatar..." name="userForm.avatar" [(ngModel)]="userForm.avatar">
+        </div>
+    </div>
+
+    <div></div>
+
+    <div class="w-full">    
+        <p class="text-sm uppercase font-semibold tracking-wide">Role</p>
+        <div class="flex items-center mt-2">
+            <select [(ngModel)]="userForm.role" class="w-full border border-gray-400 px-2 py-1 rounded">
+                <option [value]="''">None</option>
+                <option [value]="'Group Admin'">Group Administrator</option>
+                <option [value]="'Super Admin'">Super Administrator</option>
+            </select>
+        </div>
+    </div>
+    <div></div>
+
+    <div class="w-full">    
+        <p class="text-sm uppercase font-semibold tracking-wide">Password</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none border-gray-400" type="text" 
+                    placeholder="Password..." name="userForm.password" [(ngModel)]="userForm.password">
+        </div>
+    </div>
+
+    <div class="w-full">    
+        <p class="text-sm uppercase font-semibold tracking-wide">Confirm Password</p>
+        <div class="flex items-center mt-2">
+            <input class="border rounded w-full px-2 py-1 focus:outline-none border-gray-400" type="text" 
+                    placeholder="Confirm Password..." name="">
+        </div>
+    </div>
+
+</div>
+
+<div class="self-end space-x-4 mt-10">
+    <button (click)="cancel()" class="px-3 py-2 bg-blue-500 rounded text-white focus:outline-none">Cancel</button>
+    <button class="px-3 py-2 bg-green-500 rounded text-white focus:outline-none">Update</button>
+</div>
+
+</div>

--- a/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.spec.ts
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UpdateUserComponent } from './update-user.component';
+
+describe('UpdateUserComponent', () => {
+  let component: UpdateUserComponent;
+  let fixture: ComponentFixture<UpdateUserComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UpdateUserComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UpdateUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.ts
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/update-user/update-user.component.ts
@@ -1,0 +1,91 @@
+import { Component, OnInit } from '@angular/core';
+import { FormError } from 'src/app/models/classes/formError';
+import { UserForm } from 'src/app/models/interfaces/form';
+import { AuthenticationService } from 'src/app/services/authentication.service';
+import { MessageService } from 'src/app/services/message.service';
+
+@Component({
+  selector: 'app-update-user',
+  templateUrl: './update-user.component.html',
+  styleUrls: ['./update-user.component.css']
+})
+export class UpdateUserComponent implements OnInit {
+  public errors: FormError = null;
+
+  public username: string = "";
+
+  public userForm: UserForm = {
+    username: "",
+    email: "",
+    avatar: "",
+    password: "",
+    role: "",
+    active: null,
+  };
+
+
+  constructor(private auth: AuthenticationService, private messageService: MessageService) { }
+
+  ngOnInit(): void {
+    this.resetForm();
+  }
+  
+  public findUser() {
+    if (this.username != "") {
+      this.auth.findUser(this.username)
+        .catch(error => {
+          this.messageService.setMessage(error, "error");
+        })
+        .then((user: UserForm) => {
+        if (user) {
+          this.userForm = user;
+        }
+      }).catch(error => {
+        this.messageService.setMessage(error, "error");
+      });
+    } else {
+      this.messageService.setMessage("A Username is Required to Find a User", "error");
+    }
+  }
+
+  public deactivateUser() {
+    if (this.userForm.username != "") {
+      this.auth.deactivateUser(this.userForm.username)
+        .then(response => {
+          this.messageService.setMessage(response, "success");
+          this.resetForm();
+        })
+        .catch(error => {
+          this.messageService.setMessage(error, "error");
+        });
+    }
+  }
+
+  public activateUser() {
+    if (this.userForm.username != "") {
+      this.auth.activateUser(this.userForm.username)
+        .then(response => {
+          this.messageService.setMessage(response, "success");
+          this.resetForm();
+        })
+        .catch(error => {
+          this.messageService.setMessage(error, "error");
+        })
+    }
+  }
+
+  public cancel() {
+    this.resetForm();
+  }
+
+  private resetForm() {
+    this.username = "";
+    Object.keys(this.userForm).map(key => {
+      if (key == "active") {
+        this.userForm[key] = null;
+      } else {
+        this.userForm[key] = "";
+      }
+    });
+  }
+}

--- a/src/app/chat/chat-dashboard/main-panel/user-management/user-management.component.html
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/user-management.component.html
@@ -6,12 +6,12 @@
     <hr class="pb-4">
 
     <!-- tabs -->
-    <div class="flex items-center justify-between">
+    <div *ngIf="isSuperAdmin()" class="flex items-center justify-between">
         <button (click)="openTab('addUser')" class="w-full text-sm font-semibold uppercase px-2 py-2 focus:outline-none hover:bg-gray-300 {{ tab == 'addUser' ? 'bg-gray-300' : '' }}">Add User</button>
         <button (click)="openTab('updateUser')" class="w-full text-sm font-semibold uppercase px-2 py-2 focus:outline-none hover:bg-gray-300 {{ tab == 'updateUser' ? 'bg-gray-300' : '' }}">Update User</button>
-        <button (click)="openTab('removeUser')" class="w-full text-sm font-semibold uppercase px-2 py-2 focus:outline-none hover:bg-gray-300 {{ tab == 'removeUser' ? 'bg-gray-300' : '' }}">Remove User</button>
     </div>
 
     <app-add-user *ngIf="tab == 'addUser'"></app-add-user>
-
+    <app-update-user *ngIf="tab == 'updateUser'"></app-update-user>
+    
 </div>

--- a/src/app/chat/chat-dashboard/main-panel/user-management/user-management.component.ts
+++ b/src/app/chat/chat-dashboard/main-panel/user-management/user-management.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { RoomService } from 'src/app/services/room.service';
+import { AuthenticationService } from 'src/app/services/authentication.service';
 
 @Component({
   selector: 'app-user-management',
@@ -9,7 +10,7 @@ import { RoomService } from 'src/app/services/room.service';
 export class UserManagementComponent implements OnInit {
   public tab: string = "addUser";
 
-  constructor(private roomService: RoomService) { }
+  constructor(private roomService: RoomService, private auth: AuthenticationService) { }
 
   ngOnInit(): void {
   }
@@ -20,5 +21,9 @@ export class UserManagementComponent implements OnInit {
 
   public closeUserManagement(): void {
     this.roomService.isAddingUser$.next(false);
+  }
+
+  public isSuperAdmin(): boolean {
+    return this.auth.user.role == "Super Admin";
   }
 }

--- a/src/app/models/interfaces/form.ts
+++ b/src/app/models/interfaces/form.ts
@@ -23,4 +23,5 @@ export interface UserForm {
   avatar: string;
   password: string;
   role: string;
+  active: boolean;
 }

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -4,7 +4,6 @@ import { MessageService } from './message.service';
 import { Subject } from 'rxjs';
 import { DatabaseService } from './database.service';
 import { UserForm } from '../models/interfaces/form';
-import { GroupService } from './group.service';
 
 @Injectable({
   providedIn: 'root'
@@ -49,15 +48,11 @@ export class AuthenticationService {
       .then(() => {
         return new Promise((resolve, reject) => {
           this.databaseService.addUser(user).subscribe(response => {
-            if (response.ok) {
-              resolve()
-            } else {
-              reject(response.message);
-            }
+            response.ok ? resolve() : reject(response.message);
           });
         });
       })
-      .then(() => { 
+      .then(() => {
         groups.map(group => {
           this.databaseService.addUserToGroup(user.username, group).subscribe(response => {
             this.messageService.setMessage(response.message, response.ok ? "success" : "error");
@@ -67,6 +62,32 @@ export class AuthenticationService {
       .catch(error => {
         this.messageService.setMessage(error, "error");
       });
+  }
+
+  public findUser(username: string) {
+    return new Promise((resolve, reject) => {
+      this.databaseService.getUser(null, username).subscribe(response => {
+        response.ok ? resolve(response.user) : reject(response.message);
+      });
+    }).catch(error => {
+      this.messageService.setMessage(error, "error");
+    });
+  }
+
+  public deactivateUser(username: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.databaseService.deactivateUser(username).subscribe(response => {
+        response.ok ? resolve(response.message) : reject(response.message); 
+      });
+    });
+  }
+
+  public activateUser(username: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.databaseService.activateUser(username).subscribe(response => {
+        response.ok ? resolve(response.message) : reject(response.message);
+      });
+    });
   }
 
   private userExists(username: string) {

--- a/src/app/services/database.service.ts
+++ b/src/app/services/database.service.ts
@@ -7,6 +7,7 @@ import { RegistrationForm, UserForm } from '../models/interfaces/form';
 import { group } from '@angular/animations';
 import { GroupForm } from '../chat/chat-dashboard/main-panel/add-group/add-group.component';
 import { Group } from '../models/interfaces/group';
+import { ThrowStmt } from '@angular/compiler';
 
 @Injectable({
   providedIn: 'root'
@@ -35,6 +36,14 @@ export class DatabaseService {
 
   public addUser(user: UserForm) {
     return this.http.post<any>(`${this.apiUrl}/add-user`, { user: user });
+  }
+
+  public deactivateUser(username: string) {
+    return this.http.post<any>(`${this.apiUrl}/deactivate-user`, { username: username });
+  }
+
+  public activateUser(username: string) {
+    return this.http.post<any>(`${this.apiUrl}/activate-user`, { username: username });
   }
 
   public groupExists(group: string) {


### PR DESCRIPTION
## Adding / Removing Users

Implemented a screen in which Super and Group admins can create users and Super admins can remove and reactivate a users account.

### Add User

Super and Group admin views are almost the same, the only difference is that the group admin cannot see the tab menu and therefore can only access the add user view.

![image](https://user-images.githubusercontent.com/23717298/92670765-0aacf480-f358-11ea-9e3f-02794f279d83.png)

### Remove (Update) User

Super admins can update(not yet implemented, remove and reactivate user accounts 

![image](https://user-images.githubusercontent.com/23717298/92670945-72633f80-f358-11ea-954c-751660db6513.png)

Simply search for a user and then you can deactivate an account
![image](https://user-images.githubusercontent.com/23717298/92671046-a9d1ec00-f358-11ea-9189-55d7587910ef.png)

or reactivate an account.
![image](https://user-images.githubusercontent.com/23717298/92671071-b6564480-f358-11ea-9bec-68e5a3e02943.png)
